### PR TITLE
Fix infinite saving bug

### DIFF
--- a/apps/field_editor/lib/field/creator.js
+++ b/apps/field_editor/lib/field/creator.js
@@ -60,8 +60,13 @@ module.exports = class Field_Creator
 
         if(typeName == "Static")
         {
-            const titleStaticPath = this.titleBgHandler.getStaticFieldMubin(fieldSection);
-            await fs.writeFile(titleStaticPath, actorYaz);
+            try {
+                const titleStaticPath = this.titleBgHandler.getStaticFieldMubin(fieldSection);
+                await fs.writeFile(titleStaticPath, actorYaz);
+            }
+            catch(e) {
+                console.error("Exception thrown", e.stack);
+            }
         }
     }
 }


### PR DESCRIPTION
Surrounds `const titleStaticPath = this.titleBgHandler.getStaticFieldMubin(fieldSection);` (creator.js, 63) in a try/catch statement to _"fix"_ the the bug where the loading screen when saving loads infinitely.